### PR TITLE
add pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -355,6 +355,13 @@ Bugs and pull requested can be submitted on GitHub_.
 Changes
 =======
 
+2.1
+~~~
+* ENH: Add support for Python 3.5 coroutines
+* ENH: Documentation updates
+* ENH: CI for most recent Python versions (3.5, 3.6, 3.6-dev, 3.7-dev, nightly)
+* ENH: Add timer unit argument for output time granularity spec
+
 2.0
 ~~~
 * BUG: Added support for IPython 5.0+, removed support for IPython <=0.12

--- a/setup.py
+++ b/setup.py
@@ -41,13 +41,13 @@ if sys.version_info > (3, 4):
 
 setup(
     name = 'line_profiler',
-    version = '2.0',
+    version = '2.1',
     author = 'Robert Kern',
     author_email = 'robert.kern@enthought.com',
     description = 'Line-by-line profiler.',
     long_description = long_description,
     url = 'https://github.com/rkern/line_profiler',
-    download_url = 'https://github.com/rkern/line_profiler/tarball/2.0',
+    download_url = 'https://github.com/rkern/line_profiler/tarball/2.1',
     ext_modules = [
         Extension('_line_profiler',
                   sources=[line_profiler_source, 'timers.c', 'unset_trace.c'],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if sys.version_info > (3, 4):
 
 setup(
     name = 'line_profiler',
-    version = '2.1',
+    version = '2.1.1',
     author = 'Robert Kern',
     author_email = 'robert.kern@enthought.com',
     description = 'Line-by-line profiler.',


### PR DESCRIPTION
Hi,  this seems to be the new `line_profiler` repo. Pip installing it from source will fail, if cython is not installed:

```bash
ModuleNotFoundError: No module named 'Cython'
```
This problem can be solved by marking cython as build dependency using a `pyproject.toml` file [(PEP 518)](https://www.python.org/dev/peps/pep-0518/).

Also see: https://stackoverflow.com/questions/18023546/marking-cython-as-a-build-dependency